### PR TITLE
Add UNDEFINED customer type

### DIFF
--- a/lib/fortnox/api/types/enums.rb
+++ b/lib/fortnox/api/types/enums.rb
@@ -79,7 +79,7 @@ module Fortnox
         'XTS', 'XXX', 'YER', 'ZAR', 'ZMK', 'ZWD'
       )
       CustomerTypes = Types::Strict::String.enum(
-        'PRIVATE', 'COMPANY'
+        'PRIVATE', 'COMPANY', 'UNDEFINED'
       )
       VATTypes = Types::Strict::String.enum(
         'SEVAT', 'SEREVERSEDVAT', 'EUREVERSEDVAT', 'EUVAT', 'EXPORT'


### PR DESCRIPTION
Turns out, `Customer` can be not just `PRIVATE` or `COMPANY`, but also `UNDEFINED`:

> [Fortnox::API::Model::Customer.new] "UNDEFINED" (String) has invalid type for :type violates constraints (included_in?(["PRIVATE", "COMPANY"], "UNDEFINED") failed)

