### PR TITLE
Allow articles to have negative stock

### DIFF
--- a/lib/fortnox/api/models/article.rb
+++ b/lib/fortnox/api/models/article.rb
@@ -76,7 +76,7 @@ module Fortnox
         attribute :purchase_price, Types::Sized::Float[0.0, 99_999_999_999_999.9]
 
         # QuantityInStock Quantity in stock of the article
-        attribute :quantity_in_stock, Types::Sized::Float[0.0, 99_999_999_999_999.9]
+        attribute :quantity_in_stock, Types::Sized::Float[-99_999_999_999_999.9, 99_999_999_999_999.9]
 
         # ReservedQuantity Reserved quantity of the article
         attribute :reserved_quantity, Types::Nullable::Float.is(:read_only)


### PR DESCRIPTION
It works from API and frontend, despite the docs saying `quantity_in_stock` must be >= 0.