### PR TITLE
Better errors

### DIFF
--- a/lib/fortnox/api/models/base.rb
+++ b/lib/fortnox/api/models/base.rb
@@ -36,7 +36,7 @@ module Fortnox
           message = "#{exception}".sub(/\[.+?\]/, '').strip
           resource = name.split("::").last
 
-          [resource, id, message].join(" ")
+          [resource, "#{id}: ", message].join(" ").squeeze("  ").strip
         end
 
         def self.stub

--- a/lib/fortnox/api/models/base.rb
+++ b/lib/fortnox/api/models/base.rb
@@ -26,10 +26,17 @@ module Fortnox
               super(hash)
             end
           rescue Dry::Struct::Error => e
-            raise Fortnox::API::AttributeError, e
+            raise Fortnox::API::AttributeError, error_message(e, hash[self::UNIQUE_ID])
           end
 
           IceNine.deep_freeze(obj)
+        end
+
+        def self.error_message(exception, id)
+          message = "#{exception}".sub(/\[.+?\]/, '').strip
+          resource = name.split("::").last
+
+          [resource, id, message].join(" ")
         end
 
         def self.stub

--- a/spec/fortnox/api/models/base_spec.rb
+++ b/spec/fortnox/api/models/base_spec.rb
@@ -7,6 +7,8 @@ require 'fortnox/api/types'
 describe Fortnox::API::Model::Base do
   using_test_classes do
     class Entity < Fortnox::API::Model::Base
+      UNIQUE_ID = :number
+
       attribute :private, Fortnox::API::Types::String.is(:read_only)
       attribute :string, Fortnox::API::Types::Required::String
       attribute :number, Fortnox::API::Types::Nullable::Integer


### PR DESCRIPTION
Include unique resource id (customer number, article SKU etc) in error messages to help debugging.