### PR TITLE
Handle rate limit error

### DIFF
--- a/lib/fortnox/api/request_handling.rb
+++ b/lib/fortnox/api/request_handling.rb
@@ -14,10 +14,16 @@ module Fortnox
         end
 
         def validate_response(response)
-          return if response.code == 200
-
-          api_error = response.parsed_response['ErrorInformation']
-          raise_api_error(api_error, response) if api_error
+          case response.code
+          when 200
+          when 423
+            # HACK: FN doesn't actually provide JSON response in that case
+            #   they just render HTML error page.
+            raise_api_error({"message" => "Too Many Requests"}, response)
+          else
+            api_error = response.parsed_response['ErrorInformation']
+            raise_api_error(api_error, response) if api_error
+          end
         end
 
         def validate_and_parse(response)


### PR DESCRIPTION
Fixes errors like:

```
785: unexpected token at '<html>
<head><title>429 Too Many Requests</title></head>
<body>
<center><h1>429 Too Many Requests</h1></center>
<hr><center>nginx</center>
</body>
</html>
'
```

Backtrace:
```
lib/json/common.rb:156 parse
lib/httparty/parser.rb:125 json
lib/httparty/parser.rb:145 parse_supported_format
lib/httparty/parser.rb:110 parse
lib/httparty/parser.rb:69 call
lib/httparty/request.rb:334 parse_response
lib/httparty/request.rb:302 block in handle_response
lib/httparty/response.rb:35 parsed_response
/usr/local/bundle/bundler/gems/fortnox-api-32e7309a12aa/lib/fortnox/api/request_handling.rb:19 validate_response
/usr/local/bundle/bundler/gems/fortnox-api-32e7309a12aa/lib/fortnox/api/request_handling.rb:24 validate_and_parse
/usr/local/bundle/bundler/gems/fortnox-api-32e7309a12aa/lib/fortnox/api/request_handling.rb:30 execute
/usr/local/bundle/bundler/gems/fortnox-api-32e7309a12aa/lib/fortnox/api/repositories/base.rb:42 block (2 levels) in <class:Base>
/usr/local/bundle/bundler/gems/fortnox-api-32e7309a12aa/lib/fortnox/api/repositories/base/loaders.rb:34 find_one_by
/usr/local/bundle/bundler/gems/fortnox-api-32e7309a12aa/lib/fortnox/api/repositories/base/loaders.rb:30 find
```