### PR TITLE
Negative price is totally valid

### DIFF
--- a/lib/fortnox/api/types/document_row.rb
+++ b/lib/fortnox/api/types/document_row.rb
@@ -45,7 +45,7 @@ module Fortnox
         attribute :housework_type, Types::HouseworkType
 
         # Price Price per unit. 12 digits
-        attribute :price, Types::Sized::Float[0.0, 99_999_999_999.9]
+        attribute :price, Types::Sized::Float[-99_999_999_999.0, 99_999_999_999.9]
 
         # Project Code of the project for the row.
         attribute :project, Types::Nullable::String

--- a/spec/fortnox/api/types/examples/document_row.rb
+++ b/spec/fortnox/api/types/examples/document_row.rb
@@ -12,7 +12,7 @@ shared_examples_for 'DocumentRow' do |valid_hash|
 
   it { is_expected.to have_housework_type(:housework_type, valid_hash) }
 
-  it { is_expected.to have_sized_float(:price, 0.0, 99_999_999_999.9, valid_hash) }
+  it { is_expected.to have_sized_float(:price, -99_999_999_999.0, 99_999_999_999.9, valid_hash) }
 
   it do # rubocop:disable RSpec/ExampleLength
     is_expected.to have_sized_float(


### PR DESCRIPTION
The price on `DocumentRow` can be less than zero, for example credit invoices are always negative.