### PR TITLE
Allow underscores in search parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This version supports some features I needed for my projects. Key differences:
 - Invoice actions are supported ([PR](https://github.com/mbirman/fortnox-api/pull/5))
 - Multi-parameter search is allowed ([PR](https://github.com/mbirman/fortnox-api/pull/11))
 - Pagination works ([PR](https://github.com/mbirman/fortnox-api/pull/13))
+- Possible to provide human-readable search parameters (`article_number` vs `articlenumber`)([PR](https://github.com/mbirman/fortnox-api/pull/19))
 
 There are more changes, see pull-requests for additional info.
 

--- a/lib/fortnox/api/repositories/base/loaders.rb
+++ b/lib/fortnox/api/repositories/base/loaders.rb
@@ -34,7 +34,7 @@ module Fortnox
 
         def to_query(hash)
           hash.collect do |key, value|
-            escape(key, value)
+            escape("#{key}".gsub("_", ""), value)
           end.sort * '&'
         end
 


### PR DESCRIPTION
Fortnox prohibits the search parameters from being underscored and that decision affected the library design.

Turned out, converting human-readable params to the desired format (i.e. `article_number` -> `articlenumber`) is an easy task.

More information: https://developer.fortnox.se/documentation/general/parameters