### PR TITLE
Escape resource ID

### DIFF
--- a/lib/fortnox/api/repositories/base/loaders.rb
+++ b/lib/fortnox/api/repositories/base/loaders.rb
@@ -23,7 +23,7 @@ module Fortnox
         end
 
         def find_one_by(id)
-          response_hash = get("#{self.class::URI}#{id}")
+          response_hash = get("#{self.class::URI}#{CGI.escape(id.to_s)}")
           instantiate(@mapper.wrapped_json_hash_to_entity_hash(response_hash))
         end
 


### PR DESCRIPTION
The resource ids are never encoded before being used in the URL. It leads to the 400 error when an article SKU includes a slash.

```
"http": {
    "request": {
        "url": "https://api.fortnox.se:443/3/articles/TEST/01",
        "method": "PUT"
    },
    "response": {
        "status": 400
    }
}
```